### PR TITLE
Create CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.6']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          profile: minimal
+          default: true
+      - name: Install Python packages
+        run: |
+          pip install mypy pytest flake8 maturin
+      - name: Build and install wheels - x86_64
+        run: |
+          cd ulist
+          maturin develop
+      - name: Python UnitTest
+        run: |
+          cd tests
+          sh run.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,12 @@ jobs:
       - name: Install Python packages
         run: |
           pip install mypy pytest flake8 maturin
-      - name: Build and install wheels - x86_64
+      - name: Build ulist
         run: |
-          cd ulist
-          maturin develop
+          maturin build --out dist -m ulist/Cargo.toml
+      - name: Install ulist
+        run: |
+          pip install ulist --no-index --find-links dist --force-reinstall 
       - name: Python UnitTest
         run: |
           cd tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the workflow will run
@@ -11,7 +9,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# MacOS
 jobs:
   macos:
     runs-on: macos-latest
@@ -27,7 +25,38 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
+          profile: minimal
+          default: true
+      - name: Install Python packages
+        run: |
+          pip install mypy pytest flake8 maturin
+      - name: Build ulist
+        run: |
+          maturin build --out dist -m ulist/Cargo.toml
+      - name: Install ulist
+        run: |
+          pip install ulist --no-index --find-links dist --force-reinstall 
+      - name: Python UnitTest
+        run: |
+          cd tests
+          sh run.sh
+
+# Linux
+jobs:
+  macos:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           default: true
       - name: Install Python packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# MacOS
+
 jobs:
   macos:
     runs-on: macos-latest
@@ -41,9 +41,8 @@ jobs:
           cd tests
           sh run.sh
 
-# Linux
-jobs:
-  macos:
+
+  linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Create CI for Ubuntu and MacOS with Python 3.6. Although, the Python language does not provide backward compatibility, but the `ulist` does not have any Python 3rd party dependencies, so we don't have to worry too much about the compatibility with Python 3.7, 3.8, 3.9 and 3.10.