### PR TITLE
use sphinxdoc theme

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Docs Check"
 on: 
-- pull_request
+- release
 
 jobs:
   docs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'classic'
+html_theme = 'sphinxdoc'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
What's new?
- Use `sphinxdoc ` as new html theme.
- Trigger the doc build and publish action on release.