### PR TITLE
specify release type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
   # Triggers the workflow on pull request and release events
   pull_request:
   release:
+    types: [published]
 
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: "publish"
 # Controls when the workflow will run
 on:
   release:
+    types: [published]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,6 +1,7 @@
 name: "doc"
 on: 
-- release
+  release:
+    types: [published]
 
 jobs:
   docs:


### PR DESCRIPTION
Specify release type to prevent gihub from triggering actions for multiple times. Creating, modifying or publishing release all  trigger actions if not so.