### PR TITLE
Wip fix release-0.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,32 +13,33 @@ on:
 
 
 jobs:
-  strategy:
-    matrix:
-      python-version: ['3.7', '3.8', '3.9', '3.10']
-      os: [ubuntu-latest, macos-latest]
-  runs-on: ${{ matrix.os }}
-  steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        default: true
-    - name: Install Python packages
-      run: |
-        pip install mypy pytest flake8 maturin
-    - name: Build ulist
-      run: |
-        maturin build --out dist -m ulist/Cargo.toml
-    - name: Install ulist
-      run: |
-        pip install ulist --no-index --find-links dist --force-reinstall 
-    - name: Python UnitTest
-      run: |
-        cd tests
-        sh run.sh
+  tests:
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+      - name: Install Python packages
+        run: |
+          pip install mypy pytest flake8 maturin
+      - name: Build ulist
+        run: |
+          maturin build --out dist -m ulist/Cargo.toml
+      - name: Install ulist
+        run: |
+          pip install ulist --no-index --find-links dist --force-reinstall 
+      - name: Python UnitTest
+        run: |
+          cd tests
+          sh run.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,33 +13,32 @@ on:
 
 
 jobs:
-  CI:
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-      - name: Install Python packages
-        run: |
-          pip install mypy pytest flake8 maturin
-      - name: Build ulist
-        run: |
-          maturin build --out dist -m ulist/Cargo.toml
-      - name: Install ulist
-        run: |
-          pip install ulist --no-index --find-links dist --force-reinstall 
-      - name: Python UnitTest
-        run: |
-          cd tests
-          sh run.sh
+  strategy:
+    matrix:
+      python-version: ['3.7', '3.8', '3.9', '3.10']
+      os: [ubuntu-latest, macos-latest]
+  runs-on: ${{ matrix.os }}
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        default: true
+    - name: Install Python packages
+      run: |
+        pip install mypy pytest flake8 maturin
+    - name: Build ulist
+      run: |
+        maturin build --out dist -m ulist/Cargo.toml
+    - name: Install ulist
+      run: |
+        pip install ulist --no-index --find-links dist --force-reinstall 
+    - name: Python UnitTest
+      run: |
+        cd tests
+        sh run.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on pull request and release events
-  pull_request:
+  # pull_request:
   release:
     types: [published]
 
@@ -13,42 +13,12 @@ on:
 
 
 jobs:
-  macos:
-    runs-on: macos-latest
+  CI:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-      - name: Install Python packages
-        run: |
-          pip install mypy pytest flake8 maturin
-      - name: Build ulist
-        run: |
-          maturin build --out dist -m ulist/Cargo.toml
-      - name: Install ulist
-        run: |
-          pip install ulist --no-index --find-links dist --force-reinstall 
-      - name: Python UnitTest
-        run: |
-          cd tests
-          sh run.sh
-
-
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on pull request and release events
-  # pull_request:
+  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,12 @@ on:
 
 
 jobs:
-  publish:
+  maturin:
     strategy:
       matrix:
         python-version: ['3.7', '3.8']
         os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 
 jobs:
-  py37:
+  publish:
     strategy:
       matrix:
         python-version: ['3.7', '3.8']

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: "publish"
 
 # Controls when the workflow will run
 on:
+  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: "publish"
 
 # Controls when the workflow will run
 on:
-  pull_request:
   release:
     types: [published]
 
@@ -14,7 +13,7 @@ jobs:
   maturin:
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   maturin:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,6 +34,6 @@ jobs:
       - name: Publish ulist
         env:
             PYPI_PW: ${{ secrets.PYPI_PW }}
-            PYO3_PYTHON: python${{ matrix.python-version }}
+            PYTHON_VER: python${{ matrix.python-version }}
         run: |
-          maturin publish -m ulist/Cargo.toml -u tushushu -p $PYPI_PW
+          maturin publish -m ulist/Cargo.toml -u tushushu -p $PYPI_PW -i $PYTHON_VER

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,11 @@ on:
 
 
 jobs:
-  macos:
-    runs-on: macos-latest
+  py37:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8']
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -32,31 +32,6 @@ jobs:
       - name: Publish ulist
         env:
             PYPI_PW: ${{ secrets.PYPI_PW }}
-        run: |
-          maturin publish -m ulist/Cargo.toml -u tushushu -p $PYPI_PW
-
-
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-      - name: Install Python packages
-        run: |
-          pip install maturin
-      - name: Publish ulist
-        env:
-            PYPI_PW: ${{ secrets.PYPI_PW }}
+            PYO3_PYTHON: python${{ matrix.python-version }}
         run: |
           maturin publish -m ulist/Cargo.toml -u tushushu -p $PYPI_PW

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 
 jobs:
-  docs:
+  sphinx:
     runs-on: macos-latest
     strategy:
       matrix:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, tushushu'
 author = 'tushushu'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = '0.5.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/ulist/Cargo.toml
+++ b/ulist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ulist"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["tushushu"]
 edition = "2018"
 


### PR DESCRIPTION
The publish action jobs got some issue when publishing v0.5.0. PYPI won't allow you to re-publish your Python wheels with the same name even if you removed the released files, so have to fix this and re-publish as v0.5.1