### PR TITLE
Wip compare with numpy

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
       - name: Install Python packages
         run: |
           pip install numpy==1.22

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,6 @@ name: "benchmark"
 
 # Controls when the workflow will run
 on:
-  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,28 @@
+name: "benchmark"
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  timeit:
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python packages
+        run: |
+          pip install ulist
+      - name: Generate benchmarking report
+        shell: bash
+        run: |
+          cd benchmark/
+          python run.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install Python packages
         run: |
           pip install numpy==1.22
+          pip install maturin
       - name: Build ulist
         run: |
           maturin build --release --out dist -m ulist/Cargo.toml

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
           pip install numpy==1.22
       - name: Build ulist
         run: |
-          maturin build --out dist -m ulist/Cargo.toml
+          maturin build --release --out dist -m ulist/Cargo.toml
       - name: Install ulist
         run: |
           pip install ulist --no-index --find-links dist --force-reinstall 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
           pip install maturin
       - name: Build ulist
         run: |
-          maturin build --release --out dist -m ulist/Cargo.toml
+          maturin build --release --out dist -m ulist/Cargo.toml -i python
       - name: Install ulist
         run: |
           pip install ulist --no-index --find-links dist --force-reinstall 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,8 +21,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Python packages
         run: |
-          pip install ulist
           pip install numpy==1.22
+      - name: Build ulist
+        run: |
+          maturin build --out dist -m ulist/Cargo.toml
+      - name: Install ulist
+        run: |
+          pip install ulist --no-index --find-links dist --force-reinstall 
       - name: Generate benchmarking report
         shell: bash
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,7 @@ name: "benchmark"
 
 # Controls when the workflow will run
 on:
+  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -21,6 +22,7 @@ jobs:
       - name: Install Python packages
         run: |
           pip install ulist
+          pip install numpy==1.22
       - name: Generate benchmarking report
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on pull request and release events
-  # pull_request:
+  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on pull request and release events
-  pull_request:
+  # pull_request:
   release:
     types: [published]
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@
 Ulist is an ultra fast list/array data structure written in Rust with Python bindings. It aims to be the fundamental package for processing and computing 1-D list/array in Python.   
 It provides:  
 
-* an efficient, flexible and expressive 1-D list/array object;
-* broadcasting methods;
-* a SQL-like and method-chaining programming experience;
+* an efficient, flexible and expressive 1-D list/array object;  
+* broadcasting methods;  
+* a SQL-like and method-chaining programming experience;  
+
+
+### Performance
+Ulist is extremly fast, and even compared with libraries like Numpy. It is  
+* more efficient on the `string` and `boolean` array,  
+* same level efficient on the `integer` array,  
+* and a bit slower on the `floating` array.  
+Faster than Numpy is not the target of writing this repo, because they are just two different libraries. Ulist is more focused on general domain rather than just data science/machine learning/AI, for example the Linear Algebra Computation is not provided. But if you are curious about the performance, please see the [benchmarking results](https://github.com/tushushu/ulist/blob/main/benchmark.md).
 
 
 ### Requirements

--- a/benchmark.md
+++ b/benchmark.md
@@ -1,0 +1,67 @@
+### How do we benchmark?
+This benchmarking task is run by Github actions on ubuntu-latest. This document would be updated every time a new version is released.  
+
+For each dtype like `int`, `float`, `str` and `bool`, there would be some sub-tasks to compare the performances between `ulist` and `numpy`. There are 5 rounds for each sub-task with different array sizes and number of runs:
+* XS - array size 100, run 100K times;
+* S - array size 1K, run 100K times;
+* M - array size 10K, run 10K times;
+* L - array size 100K, run 1K times;
+* XL - array size 1M, run 100 times.
+
+and the result of each round and the average result are both recorded.
+
+### What does the result mean?
+The benchmark score would be displayed as a markdown table similar to below:
+
+| Item     | Dtype | XS   | S    | M    | L    | XL   | Average |
+| -------- | ----- | ---- | ---- | ---- | ---- | ---- | ------- |
+| AddOne   | int   | 0.9x | 1.0x | 1.0x | 1.0x | 1.1x | 1.0x    |
+| ArraySum | int   | 4.8x | 6.2x | 7.4x | 6.4x | 7.3x | 6.4x    |
+| EqualOne | int   | 1.3x | 1.3x | 1.0x | 0.9x | 0.8x | 1.1x    |
+
+Item - The task to compare the performances.
+Dtype - The array element type.
+
+Take the 3rd line for example, it means by running the task `EqualOne` with
+`dtype=int`, the `ulist`'s speed is 1.1 times of `numpy` on average.
+
+
+### Benchmark score
+Info:  
+************************************************************
+Date: 2022-02-26 10:38:31   
+System OS: Linux   
+CPU:  Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz   
+Python version: 3.10.2   
+Ulist version: 0.8.0   
+Numpy version: 1.22.0   
+************************************************************
+
+Result:
+
+| Item         | Dtype  | XS    | S     | M     | L     | XL    | Average | Faster |
+| ------------ | ------ | ----- | ----- | ----- | ----- | ----- | ------- | ------ |
+| AddOne       | int    | 0.9x  | 1.0x  | 1.0x  | 1.0x  | 1.1x  | 1.0x    | N      |
+| ArraySum     | int    | 6.0x  | 7.0x  | 8.4x  | 5.5x  | 7.0x  | 6.8x    | Y      |
+| CountElems   | int    | 9.7x  | 1.7x  | 0.9x  | 0.8x  | 0.9x  | 2.8x    | Y      |
+| EqualOne     | int    | 1.4x  | 1.4x  | 1.4x  | 0.9x  | 0.8x  | 1.2x    | Y      |
+| Max          | int    | 4.4x  | 3.7x  | 3.2x  | 3.0x  | 3.2x  | 3.5x    | Y      |
+| MulTwo       | int    | 1.0x  | 1.0x  | 0.8x  | 0.8x  | 0.8x  | 0.9x    | N      |
+| UniqueElem   | int    | 2.7x  | 0.5x  | 0.4x  | 0.3x  | 0.3x  | 0.8x    | N      |
+| Sort         | int    | 0.8x  | 0.6x  | 0.9x  | 0.9x  | 0.9x  | 0.8x    | N      |
+| AddOne       | float  | 1.0x  | 1.2x  | 1.2x  | 1.1x  | 1.1x  | 1.1x    | Y      |
+| ArraySum     | float  | 4.0x  | 2.0x  | 0.7x  | 0.4x  | 0.4x  | 1.5x    | Y      |
+| LessThanOne  | float  | 1.2x  | 1.2x  | 0.9x  | 0.8x  | 1.0x  | 1.0x    | N      |
+| Max          | float  | 2.9x  | 1.1x  | 0.2x  | 0.1x  | 0.1x  | 0.9x    | N      |
+| MulTwo       | float  | 1.0x  | 1.0x  | 1.1x  | 1.0x  | 1.0x  | 1.0x    | N      |
+| Sort         | float  | 0.9x  | 0.6x  | 0.7x  | 0.7x  | 0.7x  | 0.7x    | N      |
+| AllIsTrue    | bool   | 5.5x  | 3.4x  | 1.2x  | 0.7x  | 0.6x  | 2.3x    | Y      |
+| AndOp        | bool   | 0.5x  | 0.8x  | 1.3x  | 4.3x  | 3.8x  | 2.1x    | Y      |
+| AnyIsTrue    | bool   | 5.4x  | 3.4x  | 1.2x  | 0.7x  | 0.6x  | 2.3x    | Y      |
+| NotOp        | bool   | 0.6x  | 0.9x  | 1.5x  | 4.9x  | 4.5x  | 2.5x    | Y      |
+| OrOp         | bool   | 0.5x  | 0.8x  | 1.4x  | 3.6x  | 3.4x  | 1.9x    | Y      |
+| ContainsElem | string | 16.4x | 20.1x | 20.6x | 20.7x | 20.3x | 19.6x   | Y      |
+| CountElems   | string | 4.7x  | 1.7x  | 1.5x  | 1.9x  | 2.1x  | 2.4x    | Y      |
+| EqualFoo     | string | 1.2x  | 2.8x  | 3.6x  | 3.9x  | 2.5x  | 2.8x    | Y      |
+
+14 of 22 tasks are faster!

--- a/benchmark/boolean.py
+++ b/benchmark/boolean.py
@@ -1,0 +1,91 @@
+from random import choice, seed
+
+import numpy as np
+from ulist.utils import Benchmarker
+
+seed(100)
+
+
+class AllIsTrue(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([True for _ in range(100)],),
+            ([True for _ in range(1000)],),
+            ([True for _ in range(10000)],),
+            ([True for _ in range(100000)],),
+            ([True for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].all()
+
+    def other_fn(self, args) -> None:
+        args[0].all()
+
+
+class AndOp(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice([False, True]) for _ in range(100)],),
+            ([choice([False, True]) for _ in range(1000)],),
+            ([choice([False, True]) for _ in range(10000)],),
+            ([choice([False, True]) for _ in range(100000)],),
+            ([choice([False, True]) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] & args[0]
+
+    def other_fn(self, args) -> None:
+        args[0] & args[0]
+
+
+class AnyIsTrue(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([False for _ in range(100)],),
+            ([False for _ in range(1000)],),
+            ([False for _ in range(10000)],),
+            ([False for _ in range(100000)],),
+            ([False for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].any()
+
+    def other_fn(self, args) -> None:
+        args[0].any()
+
+
+class NotOp(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice([False, True]) for _ in range(100)],),
+            ([choice([False, True]) for _ in range(1000)],),
+            ([choice([False, True]) for _ in range(10000)],),
+            ([choice([False, True]) for _ in range(100000)],),
+            ([choice([False, True]) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        ~(args[0])
+
+    def other_fn(self, args) -> None:
+        ~(args[0])
+
+
+class OrOp(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice([False, True]) for _ in range(100)],),
+            ([choice([False, True]) for _ in range(1000)],),
+            ([choice([False, True]) for _ in range(10000)],),
+            ([choice([False, True]) for _ in range(100000)],),
+            ([choice([False, True]) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] | args[0]
+
+    def other_fn(self, args) -> None:
+        args[0] | args[0]

--- a/benchmark/floating.py
+++ b/benchmark/floating.py
@@ -1,0 +1,108 @@
+from random import random, seed
+
+import numpy as np
+from ulist.utils import Benchmarker
+
+seed(100)
+
+
+class AddOne(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([float(x) for x in range(100)],),
+            ([float(x) for x in range(1000)],),
+            ([float(x) for x in range(10000)],),
+            ([float(x) for x in range(100000)],),
+            ([float(x) for x in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] + 1.0
+
+    def other_fn(self, args) -> None:
+        args[0] + 1.0
+
+
+class ArraySum(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([random() for _ in range(100)],),
+            ([random() for _ in range(1000)],),
+            ([random() for _ in range(10000)],),
+            ([random() for _ in range(100000)],),
+            ([random() for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].sum()
+
+    def other_fn(self, args) -> None:
+        args[0].sum()
+
+
+class LessThanOne(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([random() * 2 for _ in range(100)],),
+            ([random() * 2 for _ in range(1000)],),
+            ([random() * 2 for _ in range(10000)],),
+            ([random() * 2 for _ in range(100000)],),
+            ([random() * 2 for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] < 1
+
+    def other_fn(self, args) -> None:
+        args[0] < 1
+
+
+class Max(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([float(x) for x in range(100)],),
+            ([float(x) for x in range(1000)],),
+            ([float(x) for x in range(10000)],),
+            ([float(x) for x in range(100000)],),
+            ([float(x) for x in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].max()
+
+    def other_fn(self, args) -> None:
+        args[0].max()
+
+
+class MulTwo(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([float(x) for x in range(100)],),
+            ([float(x) for x in range(1000)],),
+            ([float(x) for x in range(10000)],),
+            ([float(x) for x in range(100000)],),
+            ([float(x) for x in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] * 2.0
+
+    def other_fn(self, args) -> None:
+        args[0] * 2.0
+
+
+class Sort(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([random() for _ in range(100)],),
+            ([random() for _ in range(1000)],),
+            ([random() for _ in range(10000)],),
+            ([random() for _ in range(100000)],),
+            ([random() for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].sort(ascending=True)
+
+    def other_fn(self, args) -> None:
+        np.sort(args[0])

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -40,6 +40,57 @@ class ArraySum(Benchmarker):
         args[0].sum()
 
 
+class EqualOne(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([randint(1, 10) for _ in range(100)],),
+            ([randint(1, 10) for _ in range(1000)],),
+            ([randint(1, 10) for _ in range(10000)],),
+            ([randint(1, 10) for _ in range(100000)],),
+            ([randint(1, 10) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] == 1
+
+    def other_fn(self, args) -> None:
+        args[0] == 1
+
+
+class Max(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([x for x in range(100)],),
+            ([x for x in range(1000)],),
+            ([x for x in range(10000)],),
+            ([x for x in range(100000)],),
+            ([x for x in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].max()
+
+    def other_fn(self, args) -> None:
+        args[0].max()
+
+
+class MulTwo(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([x for x in range(100)],),
+            ([x for x in range(1000)],),
+            ([x for x in range(10000)],),
+            ([x for x in range(100000)],),
+            ([x for x in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] * 2
+
+    def other_fn(self, args) -> None:
+        args[0] * 2
+
+
 class UniqueElem(Benchmarker):
     def cases(self) -> list:
         return [
@@ -55,3 +106,20 @@ class UniqueElem(Benchmarker):
 
     def other_fn(self, args) -> None:
         np.unique(args[0])
+
+
+class Sort(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([randint(1, 100) for _ in range(100)],),
+            ([randint(1, 1000) for _ in range(1000)],),
+            ([randint(1, 10000) for _ in range(10000)],),
+            ([randint(1, 100000) for _ in range(100000)],),
+            ([randint(1, 1000000) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].sort(ascending=True)
+
+    def other_fn(self, args) -> None:
+        args[0].sort()

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -122,4 +122,4 @@ class Sort(Benchmarker):
         args[0].sort(ascending=True)
 
     def other_fn(self, args) -> None:
-        args[0].sort()
+        np.sort(args[0])

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -3,12 +3,9 @@ import ulist as ul
 import numpy as np
 
 
-
 class ArraySum(Benchmarker):
     def cases(self) -> list:
         return [
-            ([1],),
-            ([1] * 10,),
             ([1] * 100,),
             ([1] * 1000,),
             ([1] * 10000,),
@@ -16,14 +13,8 @@ class ArraySum(Benchmarker):
             ([1] * 1000000,),
         ]
 
-    def other_constructor(self, arr: list):
-        return np.array(arr, dtype=int)
-
     def ulist_fn(self, args) -> None:
         args[0].sum()
 
     def other_fn(self, args) -> None:
         args[0].sum()
-
-    def dtype(self) -> str:
-        return "int"

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -26,11 +26,11 @@ class AddOne(Benchmarker):
 class ArraySum(Benchmarker):
     def cases(self) -> list:
         return [
-            ([randint(1, 10) for _ in range(100)],),
-            ([randint(1, 10) for _ in range(1000)],),
-            ([randint(1, 10) for _ in range(10000)],),
-            ([randint(1, 10) for _ in range(100000)],),
-            ([randint(1, 10) for _ in range(1000000)],),
+            ([randint(-1000, 1000) for _ in range(100)],),
+            ([randint(-1000, 1000) for _ in range(1000)],),
+            ([randint(-1000, 1000) for _ in range(10000)],),
+            ([randint(-1000, 1000) for _ in range(100000)],),
+            ([randint(-1000, 1000) for _ in range(1000000)],),
         ]
 
     def ulist_fn(self, args) -> None:

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -1,0 +1,29 @@
+from ulist.utils import BenchmarkScore, Benchmarker
+import ulist as ul
+import numpy as np
+
+
+
+class ArraySum(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([1],),
+            ([1] * 10,),
+            ([1] * 100,),
+            ([1] * 1000,),
+            ([1] * 10000,),
+            ([1] * 100000,),
+            ([1] * 1000000,),
+        ]
+
+    def other_constructor(self, arr: list):
+        return np.array(arr, dtype=int)
+
+    def ulist_fn(self, args) -> None:
+        args[0].sum()
+
+    def other_fn(self, args) -> None:
+        args[0].sum()
+
+    def dtype(self) -> str:
+        return "int"

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -40,6 +40,24 @@ class ArraySum(Benchmarker):
         args[0].sum()
 
 
+class CountElems(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([randint(1, 3) for _ in range(100)], ),
+            ([randint(1, 3) for _ in range(1000)], ),
+            ([randint(1, 3) for _ in range(10000)], ),
+            ([randint(1, 3) for _ in range(100000)], ),
+            ([randint(1, 3) for _ in range(1000000)], ),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].counter()
+
+    def other_fn(self, args) -> None:
+        unique, counts = np.unique(args[0], return_counts=True)
+        dict(zip(unique, counts))
+
+
 class EqualOne(Benchmarker):
     def cases(self) -> list:
         return [

--- a/benchmark/integer.py
+++ b/benchmark/integer.py
@@ -1,16 +1,36 @@
-from ulist.utils import BenchmarkScore, Benchmarker
-import ulist as ul
+from random import randint, seed
+
 import numpy as np
+from ulist.utils import Benchmarker
+
+seed(100)
+
+
+class AddOne(Benchmarker):
+    def cases(self) -> list:
+        return [
+            (list(range(100)),),
+            (list(range(1000)),),
+            (list(range(10000)),),
+            (list(range(100000)),),
+            (list(range(1000000)),),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] + 1
+
+    def other_fn(self, args) -> None:
+        args[0] + 1
 
 
 class ArraySum(Benchmarker):
     def cases(self) -> list:
         return [
-            ([1] * 100,),
-            ([1] * 1000,),
-            ([1] * 10000,),
-            ([1] * 100000,),
-            ([1] * 1000000,),
+            ([randint(1, 10) for _ in range(100)],),
+            ([randint(1, 10) for _ in range(1000)],),
+            ([randint(1, 10) for _ in range(10000)],),
+            ([randint(1, 10) for _ in range(100000)],),
+            ([randint(1, 10) for _ in range(1000000)],),
         ]
 
     def ulist_fn(self, args) -> None:
@@ -18,3 +38,20 @@ class ArraySum(Benchmarker):
 
     def other_fn(self, args) -> None:
         args[0].sum()
+
+
+class UniqueElem(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([randint(1, 10) for _ in range(100)],),
+            ([randint(1, 10) for _ in range(1000)],),
+            ([randint(1, 10) for _ in range(10000)],),
+            ([randint(1, 10) for _ in range(100000)],),
+            ([randint(1, 10) for _ in range(1000000)],),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].unique()
+
+    def other_fn(self, args) -> None:
+        np.unique(args[0])

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -52,10 +52,10 @@ def display_result():
     n_wins = 0
     total = 0
     iterator = chain(
-        # I32.__dict__.values(),
-        # F32.__dict__.values(),
+        I32.__dict__.values(),
+        F32.__dict__.values(),
         BOOL.__dict__.values(),
-        # STR.__dict__.values(),
+        STR.__dict__.values(),
     )
     for cls in iterator:
         if not isclass(cls):
@@ -73,16 +73,13 @@ def display_result():
             total += 1
         gc.collect()
     print()
-    print(f"Total {total} tasks, and ulist is faster in {n_wins} of them.")
+    print(f"{n_wins} of {total} tasks are faster!")
 
 
 def main():
     """
-    Comparing Ulist and Numpy performances, and output the
-    result as Markdown Table.
-        Item - The task to compare the performances.
-        Dtype - The array element type.
-        Sample Vol. - {XS: 100, S: 1k, M: 10k, L: 100k, XL: 1M}.
+    Comparing Ulist and Numpy performances, show the server info and output
+    the result as Markdown Table.
     """
     print("GC disabled...")
     gc.disable()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,6 +1,22 @@
 from integer import ArraySum
+import platform
+import ulist as ul
+import numpy as np
 
 if __name__ == "__main__":
     print("Benchmarking...")
+    print()
+
+    line = "=" * 32
+    print(line)
+    print("System OS:", platform.system())
+    print("Ulist version:", ul.__version__)
+    print("Numpy version:", np.__version__)
+    print(line)
+    print()
+
     result = ArraySum().run()
+    line = "-" * 128
+    print(line)
     print(result.name, result.dtype, result.scores)
+    print(line)

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -39,7 +39,6 @@ def display_result():
         F32.__dict__.values(),
     )
     for cls in iterator:
-        print(cls)
         if not isclass(cls):
             continue
         if cls is Benchmarker:
@@ -67,7 +66,7 @@ def main():
     gc.disable()
     print("Benchmarking...\n")
     display_info()
-    # display_result()
+    display_result()
     print("GC enabled...")
     gc.enable()
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -82,7 +82,7 @@ def main():
     gc.disable()
     print("Benchmarking...\n")
     display_info()
-    # display_result()
+    display_result()
     print("GC enabled...")
     gc.enable()
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,21 +1,12 @@
-from integer import ArraySum
+import integer as I32
+from inspect import isclass
 import platform
 import ulist as ul
 import numpy as np
 from datetime import datetime
 
 
-def main():
-    """
-    Comparing Ulist and Numpy performances, and output the
-    result as Markdown Table.
-        Item - The task to compare the performances.
-        Dtype - The array element type.
-        Sample Vol. - {XS: 100, S: 1k, M: 10k, L: 100k, XL: 1M}.
-    """
-    print("Benchmarking...")
-    print()
-
+def display_info() -> None:
     print("Info:")
     line = "=" * 60
     print(line)
@@ -29,12 +20,37 @@ def main():
     print(line)
     print()
 
+
+def display_result():
     print("Result:")
     print()
-    result = ArraySum().run()
-    result.display()
+    i = 0
+    for cls in I32.__dict__.values():
+        if not isclass(cls):
+            continue
+        if cls is I32.Benchmarker:
+            continue
+        if issubclass(cls, I32.Benchmarker):
+            result = cls().run()
+            if i == 0:
+                result.display()
+            else:
+                result.display(False)
+            i += 1
     print()
 
+
+def main():
+    """
+    Comparing Ulist and Numpy performances, and output the
+    result as Markdown Table.
+        Item - The task to compare the performances.
+        Dtype - The array element type.
+        Sample Vol. - {XS: 100, S: 1k, M: 10k, L: 100k, XL: 1M}.
+    """
+    print("Benchmarking...\n")
+    display_info()
+    display_result()
 
 if __name__ == "__main__":
     main()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -23,12 +23,8 @@ def _get_processor_name() -> str:
         command = "sysctl -n machdep.cpu.brand_string".split()
         return subprocess.check_output(command).strip().decode()
     elif platform.system() == "Linux":
-        command = "cat /proc/cpuinfo".split()
-        all_info = subprocess.check_output(
-            command, shell=True).strip().decode()
-        for line in all_info.split("\n"):
-            if "model name" in line:
-                return re.sub(".*model name.*:", "", line, 1)
+        command = "cat /proc/cpuinfo | grep 'model name' | uniq".split()
+        return subprocess.check_output(command).strip().decode()
     return ""
 
 
@@ -86,7 +82,7 @@ def main():
     gc.disable()
     print("Benchmarking...\n")
     display_info()
-    display_result()
+    # display_result()
     print("GC enabled...")
     gc.enable()
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,0 +1,6 @@
+from integer import ArraySum
+
+if __name__ == "__main__":
+    print("Benchmarking...")
+    result = ArraySum().run()
+    print(result.name, result.dtype, result.scores)

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -2,21 +2,24 @@ from integer import ArraySum
 import platform
 import ulist as ul
 import numpy as np
+from datetime import datetime
 
 if __name__ == "__main__":
     print("Benchmarking...")
     print()
 
+    print("Info:")
     line = "=" * 32
     print(line)
+    print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
     print("System OS:", platform.system())
     print("Ulist version:", ul.__version__)
     print("Numpy version:", np.__version__)
     print(line)
     print()
 
+    print("Result:")
+    print()
     result = ArraySum().run()
-    line = "-" * 128
-    print(line)
-    print(result.name, result.dtype, result.scores)
-    print(line)
+    result.display()
+    print()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,5 +1,8 @@
 import gc
+import os
 import platform
+import re
+import subprocess
 import sys
 from datetime import datetime
 from inspect import isclass
@@ -13,12 +16,29 @@ import floating as F32
 import integer as I32
 
 
+def _get_processor_name() -> str:
+    if platform.system() == "Windows":
+        return platform.processor()
+    elif platform.system() == "Darwin":
+        command = "sysctl -n machdep.cpu.brand_string".split()
+        return subprocess.check_output(command).strip().decode()
+    elif platform.system() == "Linux":
+        command = "cat /proc/cpuinfo".split()
+        all_info = subprocess.check_output(
+            command, shell=True).strip().decode()
+        for line in all_info.split("\n"):
+            if "model name" in line:
+                return re.sub(".*model name.*:", "", line, 1)
+    return ""
+
+
 def display_info() -> None:
     print("Info:")
     line = "=" * 60
     print(line)
     print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
     print("System OS:", platform.system())
+    print("CPU:", _get_processor_name())
     print("Python version:", sys.version.split()[0])
 
     try:

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 import numpy as np
 import ulist as ul
+from ulist.utils import Benchmarker
 
 import floating as F32
 import integer as I32
@@ -38,11 +39,12 @@ def display_result():
         F32.__dict__.values(),
     )
     for cls in iterator:
+        print(cls)
         if not isclass(cls):
             continue
-        if cls is I32.Benchmarker:
+        if cls is Benchmarker:
             continue
-        if issubclass(cls, I32.Benchmarker):
+        if issubclass(cls, Benchmarker):
             result = cls().run()
             if i == 0:
                 result.display()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,9 +1,12 @@
-import integer as I32
-from inspect import isclass
+import gc
 import platform
-import ulist as ul
-import numpy as np
 from datetime import datetime
+from inspect import isclass
+
+import numpy as np
+import ulist as ul
+
+import integer as I32
 
 
 def display_info() -> None:
@@ -48,9 +51,14 @@ def main():
         Dtype - The array element type.
         Sample Vol. - {XS: 100, S: 1k, M: 10k, L: 100k, XL: 1M}.
     """
+    print("GC disabled...")
+    gc.disable()
     print("Benchmarking...\n")
     display_info()
     display_result()
+    print("GC enabled...")
+    gc.enable()
+
 
 if __name__ == "__main__":
     main()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -29,19 +29,19 @@ def _get_processor_name() -> str:
 
 
 def display_info() -> None:
-    print("Info:")
-    line = "=" * 60
+    print("Info:  ")
+    line = "*" * 60
     print(line)
-    print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
-    print("System OS:", platform.system())
-    print("CPU:", _get_processor_name())
-    print("Python version:", sys.version.split()[0])
+    print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"), "  ")
+    print("System OS:", platform.system(), "  ")
+    print("CPU:", _get_processor_name(), "  ")
+    print("Python version:", sys.version.split()[0], "  ")
 
     try:
-        print("Ulist version:", ul.__version__)
+        print("Ulist version:", ul.__version__, "  ")
     except:
         print("Ulist version:", "unknown")
-    print("Numpy version:", np.__version__)
+    print("Numpy version:", np.__version__, "  ")
     print(line)
     print()
 
@@ -49,12 +49,13 @@ def display_info() -> None:
 def display_result():
     print("Result:")
     print()
-    i = 0
+    n_wins = 0
+    total = 0
     iterator = chain(
-        I32.__dict__.values(),
-        F32.__dict__.values(),
+        # I32.__dict__.values(),
+        # F32.__dict__.values(),
         BOOL.__dict__.values(),
-        STR.__dict__.values(),
+        # STR.__dict__.values(),
     )
     for cls in iterator:
         if not isclass(cls):
@@ -63,13 +64,16 @@ def display_result():
             continue
         if issubclass(cls, Benchmarker):
             result = cls().run()
-            if i == 0:
+            if total == 0:
                 result.display()
             else:
                 result.display(False)
-            i += 1
+            if result.scores[-1] == 'Y':
+                n_wins += 1
+            total += 1
         gc.collect()
     print()
+    print(f"Total {total} tasks, and ulist is faster in {n_wins} of them.")
 
 
 def main():

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,7 +1,5 @@
 import gc
-import os
 import platform
-import re
 import subprocess
 import sys
 from datetime import datetime
@@ -15,6 +13,7 @@ from ulist.utils import Benchmarker
 import boolean as BOOL
 import floating as F32
 import integer as I32
+import strings as STR
 
 
 def _get_processor_name() -> str:
@@ -55,6 +54,7 @@ def display_result():
         I32.__dict__.values(),
         F32.__dict__.values(),
         BOOL.__dict__.values(),
+        STR.__dict__.values(),
     )
     for cls in iterator:
         if not isclass(cls):

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -4,16 +4,27 @@ import ulist as ul
 import numpy as np
 from datetime import datetime
 
-if __name__ == "__main__":
+
+def main():
+    """
+    Comparing Ulist and Numpy performances, and output the
+    result as Markdown Table.
+        Item - The task to compare the performances.
+        Dtype - The array element type.
+        Sample Vol. - {XS: 100, S: 1k, M: 10k, L: 100k, XL: 1M}.
+    """
     print("Benchmarking...")
     print()
 
     print("Info:")
-    line = "=" * 32
+    line = "=" * 60
     print(line)
     print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
     print("System OS:", platform.system())
-    print("Ulist version:", ul.__version__)
+    try:
+        print("Ulist version:", ul.__version__)
+    except:
+        print("Ulist version:", "unknown")
     print("Numpy version:", np.__version__)
     print(line)
     print()
@@ -23,3 +34,7 @@ if __name__ == "__main__":
     result = ArraySum().run()
     result.display()
     print()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -12,6 +12,7 @@ import numpy as np
 import ulist as ul
 from ulist.utils import Benchmarker
 
+import boolean as BOOL
 import floating as F32
 import integer as I32
 
@@ -53,6 +54,7 @@ def display_result():
     iterator = chain(
         I32.__dict__.values(),
         F32.__dict__.values(),
+        BOOL.__dict__.values(),
     )
     for cls in iterator:
         if not isclass(cls):

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,5 +1,6 @@
 import gc
 import platform
+import sys
 from datetime import datetime
 from inspect import isclass
 
@@ -15,6 +16,8 @@ def display_info() -> None:
     print(line)
     print("Date:", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
     print("System OS:", platform.system())
+    print("Python version:", sys.version.split()[0])
+
     try:
         print("Ulist version:", ul.__version__)
     except:
@@ -55,7 +58,7 @@ def main():
     gc.disable()
     print("Benchmarking...\n")
     display_info()
-    display_result()
+    # display_result()
     print("GC enabled...")
     gc.enable()
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -7,7 +7,6 @@ from itertools import chain
 
 import numpy as np
 import ulist as ul
-from ulist.utils import Benchmarker
 
 import floating as F32
 import integer as I32
@@ -41,9 +40,9 @@ def display_result():
     for cls in iterator:
         if not isclass(cls):
             continue
-        if cls is Benchmarker:
+        if cls is I32.Benchmarker:
             continue
-        if issubclass(cls, Benchmarker):
+        if issubclass(cls, I32.Benchmarker):
             result = cls().run()
             if i == 0:
                 result.display()

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -20,11 +20,11 @@ def _get_processor_name() -> str:
     if platform.system() == "Windows":
         return platform.processor()
     elif platform.system() == "Darwin":
-        command = "sysctl -n machdep.cpu.brand_string".split()
-        return subprocess.check_output(command).strip().decode()
+        command = "sysctl -n machdep.cpu.brand_string"
+        return subprocess.check_output(command, shell=True).strip().decode()
     elif platform.system() == "Linux":
-        command = "cat /proc/cpuinfo | grep 'model name' | uniq".split()
-        return subprocess.check_output(command).strip().decode()
+        command = "cat /proc/cpuinfo | grep 'model name' | uniq"
+        return subprocess.check_output(command, shell=True).strip().decode()
     return ""
 
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -3,10 +3,13 @@ import platform
 import sys
 from datetime import datetime
 from inspect import isclass
+from itertools import chain
 
 import numpy as np
 import ulist as ul
+from ulist.utils import Benchmarker
 
+import floating as F32
 import integer as I32
 
 
@@ -31,18 +34,23 @@ def display_result():
     print("Result:")
     print()
     i = 0
-    for cls in I32.__dict__.values():
+    iterator = chain(
+        I32.__dict__.values(),
+        F32.__dict__.values(),
+    )
+    for cls in iterator:
         if not isclass(cls):
             continue
-        if cls is I32.Benchmarker:
+        if cls is Benchmarker:
             continue
-        if issubclass(cls, I32.Benchmarker):
+        if issubclass(cls, Benchmarker):
             result = cls().run()
             if i == 0:
                 result.display()
             else:
                 result.display(False)
             i += 1
+        gc.collect()
     print()
 
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -24,7 +24,7 @@ def _get_processor_name() -> str:
         return subprocess.check_output(command, shell=True).strip().decode()
     elif platform.system() == "Linux":
         command = "cat /proc/cpuinfo | grep 'model name' | uniq"
-        return subprocess.check_output(command, shell=True).strip().decode()
+        return subprocess.check_output(command, shell=True).strip().decode().split(":")[1]
     return ""
 
 

--- a/benchmark/strings.py
+++ b/benchmark/strings.py
@@ -1,0 +1,63 @@
+from random import choice, seed
+
+import numpy as np
+from ulist.utils import Benchmarker
+
+seed(100)
+
+
+class ContainsElem(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice(['How are you?', 'I am fine!'])
+             for _ in range(100)], 'fine'),
+            ([choice(['How are you?', 'I am fine!'])
+             for _ in range(1000)], 'fine'),
+            ([choice(['How are you?', 'I am fine!'])
+             for _ in range(10000)], 'fine'),
+            ([choice(['How are you?', 'I am fine!'])
+             for _ in range(100000)], 'fine'),
+            ([choice(['How are you?', 'I am fine!'])
+             for _ in range(1000000)], 'fine'),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].contains(args[1])
+
+    def other_fn(self, args) -> None:
+        np.char.find(args[0], args[1]) != -1
+
+
+class CountElems(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice(['foo', 'bar', 'baz']) for _ in range(100)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(1000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(10000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(100000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(1000000)], ),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0].counter()
+
+    def other_fn(self, args) -> None:
+        unique, counts = np.unique(args[0], return_counts=True)
+        dict(zip(unique, counts))
+
+
+class EqualFoo(Benchmarker):
+    def cases(self) -> list:
+        return [
+            ([choice(['foo', 'bar', 'baz']) for _ in range(100)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(1000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(10000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(100000)], ),
+            ([choice(['foo', 'bar', 'baz']) for _ in range(1000000)], ),
+        ]
+
+    def ulist_fn(self, args) -> None:
+        args[0] == 'foo'
+
+    def other_fn(self, args) -> None:
+        args[0] == 'foo'

--- a/ulist/python/ulist/__init__.py
+++ b/ulist/python/ulist/__init__.py
@@ -1,3 +1,5 @@
 from .constructor import arange, cycle, from_seq, repeat  # noqa:F401
 from .control_flow import select  # noqa:F401
 from .core import UltraFastList  # noqa:F401
+
+__version__ = "0.8.0"

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -62,7 +62,7 @@ class BenchmarkScore:
         result = [self.name, self.dtype]
         for v in self.scores.values():
             result.append(str(v) + 'x')
-        avg = sum(self.scores.values()) / len(self.scores)
+        avg = round(sum(self.scores.values()) / len(self.scores), 1)
         result.append(str(avg) + 'x')
         return result
 

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -86,26 +86,37 @@ class BenchmarkScore:
         return ['-' * (x - 2) for x in cell_sizes]
 
     @property
-    def _header(self) -> list:
-        return ['Item', 'Dtype', 'XS', 'S', 'M', 'L', 'XL', 'Average', 'Faster']
+    def _header(self) -> List[str]:
+        return [
+            'Item',
+            'Dtype',
+            'XS',
+            'S',
+            'M',
+            'L',
+            'XL',
+            'Average',
+            'Faster'
+        ]
 
     def display(self, show_header: bool = True) -> None:
         """
         Display the benchmark score as a markdown table similar to below:
 
         --------
-        | Item           | Dtype  | XS   | S    | M    | L    | XL   | Average |
-        | -------------- | ------ | ---- | ---- | ---- | ---- | ---- | ------- |
-        | AddOne         | int    | 0.9x | 1.0x | 1.0x | 1.0x | 1.1x | 1.0x    |
-        | ArraySum       | int    | 4.8x | 6.2x | 7.4x | 6.4x | 7.3x | 6.4x    |
-        | EqualOne       | int    | 1.3x | 1.3x | 1.0x | 0.9x | 0.8x | 1.1x    |
+        | Item     | Dtype | XS   | S    | M    | L    | XL   | Average |
+        | -------  | ------| ---- | ---- | ---- | ---- | ---- | ------- |
+        | AddOne   | int   | 0.9x | 1.0x | 1.0x | 1.0x | 1.1x | 1.0x    |
+        | ArraySum | int   | 4.8x | 6.2x | 7.4x | 6.4x | 7.3x | 6.4x    |
+        | EqualOne | int   | 1.3x | 1.3x | 1.0x | 0.9x | 0.8x | 1.1x    |
 
         Item - The task to compare the performances.
         Dtype - The array element type.
         Sample Vol. - See `Benchmarker`.
 
-        Take the 3rd line for example, it means by running the task EqualOne with
-        dtype=int, the ulist's speed is 1.1 times of numpy on average.
+        Take the 3rd line for example, it means by running the task
+        EqualOne with dtype=int, the ulist's speed is 1.1 times of numpy
+        on average.
         """
         cell_sizes = [max(6, len(x) + 2) for x in self._header]
         cell_sizes[0] = MAX_ITEM_LEN

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -1,8 +1,10 @@
-from typing import Callable, Union
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Union, List
 
 import ulist as ul
 
-from .typedef import ELEM, LIST_PY, COUNTER
+from .typedef import COUNTER, ELEM, LIST_PY
 
 
 def check_test_result(
@@ -41,3 +43,27 @@ def check_test_result(
     else:
         assert type(result) == type(expected_value), msg
         assert result == expected_value, msg
+
+
+@dataclass
+class BenchmarkScore:
+    pass
+
+
+class Benchmarker(ABC):
+    def __init__(self, n_runs: List[int], n_times: List[int]) -> None:
+        super().__init__()
+        assert len(n_runs) == len(n_times)
+        self.n_runs = n_runs
+        self.n_times = n_times
+
+    @abstractmethod
+    def one(self) -> None:
+        pass
+
+    @abstractmethod
+    def the_other(self) -> None:
+        pass
+
+    def run(self) -> BenchmarkScore:
+        pass

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -2,9 +2,10 @@ from abc import ABC, abstractmethod
 from copyreg import constructor
 from dataclasses import dataclass
 from timeit import timeit
-from typing import Callable, Dict, Tuple, Union, Sequence, Any
+from typing import Callable, Dict, Union, Sequence, Any, List
 
 import ulist as ul
+import numpy as np
 
 from .typedef import COUNTER, ELEM, LIST_PY
 
@@ -56,13 +57,16 @@ class BenchmarkScore:
     dtype: str
     scores: dict
 
-    def _score(self) -> list:
+    @property
+    def _score(self) -> List[str]:
         result = [self.name, self.dtype]
         for v in self.scores.values():
             result.append(str(v) + 'x')
+        avg = sum(self.scores.values()) / len(self.scores)
+        result.append(str(avg) + 'x')
         return result
 
-    def _as_markdown(self, text: list, cell_sizes: list) -> str:
+    def _as_markdown(self, text: List[str], cell_sizes: List[int]) -> str:
         result = ['|']
         for t, cell_size in zip(text, cell_sizes):
             content = [' '] * cell_size
@@ -75,27 +79,23 @@ class BenchmarkScore:
             result.append('|')
         return "".join(result)
 
-    def _line(self, cell_sizes: list) -> list:
+    def _line(self, cell_sizes: List[int]) -> List[str]:
         return ['-' * (x - 2) for x in cell_sizes]
 
+    @property
     def _header(self) -> list:
-        result = ['Item', 'Dtype']
-        for v in self.scores.keys():
-            result.append('Size ' + str(v))
-        return result
+        return ['Item', 'Dtype', 'XS', 'S', 'M', 'L', 'XL', 'Average']
 
     def display(self, show_header: bool = True) -> None:
         if show_header:
-            cell_sizes = [max(6, len(x) + 2) for x in self._header()]
+            cell_sizes = [max(6, len(x) + 2) for x in self._header]
             cell_sizes[0] = MAX_ITEM_LEN
             cell_sizes[1] = MAX_DTYPE_LEN
-            header = self._header()
-            print(self._as_markdown(header, cell_sizes))
+            print(self._as_markdown(self._header, cell_sizes))
             line = self._line(cell_sizes)
             print(self._as_markdown(line, cell_sizes))
 
-        score = self._score()
-        print((self._as_markdown(score, cell_sizes)))
+        print((self._as_markdown(self._score, cell_sizes)))
 
 
 class Benchmarker(ABC):
@@ -104,30 +104,31 @@ class Benchmarker(ABC):
     framework such as `numpy`.
     """
 
-    def __init__(
-        self,
-        n_runs: Union[int, Tuple[int, ...]] = 10,
-        sizes: Tuple[int, ...] = (1, 10, 100, 1000, 10000, 100000, 1000000)
-    ) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        if isinstance(n_runs, int):
-            n_runs = tuple([n_runs] * len(sizes))
-        else:
-            assert len(n_runs) == len(sizes)
-        assert len(n_runs) == len(self.cases())
-        assert all(x == len(y[0]) for x, y in zip(sizes, self.cases()))
+        self.n_runs = (1000, 1000, 1000, 100, 10)
+        self.sizes = (100, 1000, 10000, 100000, 1000000)
+        assert len(self.n_runs) == len(self.cases())
+        assert all(x == len(y[0]) for x, y in zip(self.sizes, self.cases()))
         assert len(self.dtype()) < MAX_DTYPE_LEN
         assert len(self.__class__.__name__) < MAX_ITEM_LEN
-        self.n_runs = n_runs
-        self.sizes = sizes
 
     @abstractmethod
     def cases(self) -> list:
         pass
 
-    @abstractmethod
-    def other_constructor(self, arr: list) -> Any:
-        pass
+    def other_constructor(self, arr: list):
+        if isinstance(arr[0], int):
+            dtype = "int32"
+        elif isinstance(arr[0], float):
+            dtype = "float32"
+        elif isinstance(arr[0], bool):
+            dtype = "bool"
+        elif isinstance(arr[0], str):
+            dtype = "object"
+        else:
+            raise TypeError(f"Invalid type {type(arr[0])}!")
+        return np.array(arr, dtype=dtype)
 
     @abstractmethod
     def ulist_fn(self, args: Sequence[Any]) -> None:
@@ -137,9 +138,14 @@ class Benchmarker(ABC):
     def other_fn(self, args: Sequence[Any]) -> None:
         pass
 
-    @abstractmethod
     def dtype(self) -> str:
-        pass
+        element_type = str(type(self.cases()[0][0][0]))
+        left = element_type.index("'") + 1
+        right = element_type.rindex("'")
+        result = element_type[left: right]
+        if result == 'str':
+            return 'string'
+        return result
 
     def run(self) -> BenchmarkScore:
         ulist_time_elapsed = self._run(self.ulist_fn)

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -100,6 +100,10 @@ class BenchmarkScore:
         | ArraySum       | int    | 4.8x | 6.2x | 7.4x | 6.4x | 7.3x | 6.4x    |
         | EqualOne       | int    | 1.3x | 1.3x | 1.0x | 0.9x | 0.8x | 1.1x    |
 
+        Item - The task to compare the performances.
+        Dtype - The array element type.
+        Sample Vol. - See `Benchmarker`.
+
         Take the 3rd line for example, it means by running the task EqualOne with
         dtype=int, the ulist's speed is 1.1 times of numpy on average.
         """
@@ -120,12 +124,13 @@ class Benchmarker(ABC):
     An abstract class for comparing the performance between `ulist` and other
     framework such as `numpy`.
 
-    There are 5 rounds for the task:
-        XS - array size 100, run 100000 times;
-        S - array size 1000, run 100000 times;
-        M - array size 10000, run 10000 times;
-        L - array size 100000, run 1000 times;
-        XL - array size 1000000, run 100 times.
+    There are 5 rounds for the task with different array sizes and number of
+    runs:
+        XS - array size 100, run 100K times;
+        S - array size 1K, run 100K times;
+        M - array size 10K, run 10K times;
+        L - array size 100K, run 1K times;
+        XL - array size 1M, run 100 times.
 
     and the result of each round and the average result are both recorded.
     """

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -1,11 +1,9 @@
 from abc import ABC, abstractmethod
-from copyreg import constructor
 from dataclasses import dataclass
 from timeit import timeit
-from typing import Callable, Dict, Union, Sequence, Any, List
+from typing import Any, Callable, Dict, List, Sequence, Union
 
 import ulist as ul
-import numpy as np
 
 from .typedef import COUNTER, ELEM, LIST_PY
 
@@ -119,6 +117,7 @@ class Benchmarker(ABC):
         pass
 
     def other_constructor(self, arr: list):
+        import numpy as np  # type: ignore
         if isinstance(arr[0], int):
             dtype = "int32"
         elif isinstance(arr[0], float):
@@ -151,9 +150,9 @@ class Benchmarker(ABC):
     def run(self) -> BenchmarkScore:
         ulist_time_elapsed = self._run(self.ulist_fn)
         other_time_elapsed = self._run(self.other_fn)
-        scores = {
-            k: round(other_time_elapsed[k] / v, 1) for k, v in ulist_time_elapsed.items()
-        }
+        scores = dict()
+        for k, v in ulist_time_elapsed.items():
+            scores[k] = round(other_time_elapsed[k] / v, 1)
         return BenchmarkScore(
             name=type(self).__name__,
             dtype=self.dtype(),
@@ -172,7 +171,11 @@ class Benchmarker(ABC):
             result[size] = timeit(lambda: fn(_args), number=n_run)
         return result
 
-    def _process_args(self, args: Sequence[Any], constructor: Callable) -> list:
+    def _process_args(
+        self,
+        args: Sequence[Any],
+        constructor: Callable
+    ) -> list:
         result = []
         for arg in args:
             if isinstance(arg, list):

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -87,10 +87,11 @@ class BenchmarkScore:
         return ['Item', 'Dtype', 'XS', 'S', 'M', 'L', 'XL', 'Average']
 
     def display(self, show_header: bool = True) -> None:
+        cell_sizes = [max(6, len(x) + 2) for x in self._header]
+        cell_sizes[0] = MAX_ITEM_LEN
+        cell_sizes[1] = MAX_DTYPE_LEN
+
         if show_header:
-            cell_sizes = [max(6, len(x) + 2) for x in self._header]
-            cell_sizes[0] = MAX_ITEM_LEN
-            cell_sizes[1] = MAX_DTYPE_LEN
             print(self._as_markdown(self._header, cell_sizes))
             line = self._line(cell_sizes)
             print(self._as_markdown(line, cell_sizes))

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -107,7 +107,7 @@ class Benchmarker(ABC):
 
     def __init__(self) -> None:
         super().__init__()
-        self.n_runs = (1000, 1000, 1000, 100, 10)
+        self.n_runs = (100000, 100000, 10000, 1000, 100)
         self.sizes = (100, 1000, 10000, 100000, 1000000)
         assert len(self.n_runs) == len(self.cases())
         assert all(x == len(y[0]) for x, y in zip(self.sizes, self.cases()))

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -125,7 +125,7 @@ class Benchmarker(ABC):
         elif isinstance(arr[0], bool):
             dtype = "bool"
         elif isinstance(arr[0], str):
-            dtype = "object"
+            dtype = "str"
         else:
             raise TypeError(f"Invalid type {type(arr[0])}!")
         return np.array(arr, dtype=dtype)

--- a/ulist/python/ulist/utils.py
+++ b/ulist/python/ulist/utils.py
@@ -51,11 +51,15 @@ class BenchmarkScore:
 
 
 class Benchmarker(ABC):
-    def __init__(self, n_runs: List[int], n_times: List[int]) -> None:
+    def __init__(self, n_runs: List[int], sizes: List[int]) -> None:
         super().__init__()
-        assert len(n_runs) == len(n_times)
+        assert len(n_runs) == len(sizes)
         self.n_runs = n_runs
-        self.n_times = n_times
+        self.sizes = sizes
+
+    @abstractmethod
+    def cases(self) -> list:
+        pass
 
     @abstractmethod
     def one(self) -> None:


### PR DESCRIPTION
What's New?
* Implement `Benchmarker` class to compare performances between `ulist` and `numpy`;
* Github action to calculate benchmarking core;
* Markdown doc to save the benchmarking core;
* Add `performance` paragraph in `Readme.md`;
* Write benchmark scripts for `Integer` dtype including `add`, `counter`, `mul`, `max`, `equal`, `unique`, `sum` and `sort` methods;
* Write benchmark scripts for `Float` dtype including `add`, `mul`, `max`, `less_than`, `sum` and `sort` methods;
* Write benchmark scripts for `Boolean` dtype including `all`, `and_`, `any`, `not_`, `or_` methods;
* Write benchmark scripts for `String` dtype including `contains`, `counter` and `equal` methods.